### PR TITLE
Add possibility to copy the commit hash to clipboard

### DIFF
--- a/lib/blame-gutter-view.coffee
+++ b/lib/blame-gutter-view.coffee
@@ -57,13 +57,16 @@ class BlameGutterView
           else
             rowCls = 'blame-odd'
         else
-          lineStr= '<br>'
+          lineStr= ''
 
         lastHash = hash
 
         @addMarker idx, hash, rowCls, lineStr
 
   itemClicked: (hash) ->
+  copyClicked: (event) =>
+    hash = event.path[0].getAttribute('data-hash')
+    atom.clipboard.write hash
 
   formateData: (date) ->
     date = new Date date
@@ -79,8 +82,12 @@ class BlameGutterView
     item = document.createElement('div')
     item.classList.add 'blame-gutter-inner'
     item.classList.add rowCls
-    item.innerHTML = lineStr
-    item.addEventListener 'click', => @itemClicked(hash)
+
+    # no need to create objects and events on blank lines
+    if lineStr.length > 0
+      item.appendChild(@copySpan hash)
+      item.appendChild(@wrap lineStr)
+      item.addEventListener 'click', => @itemClicked(hash)
 
     resizeHandle = document.createElement('div')
     resizeHandle.addEventListener 'mousedown', @resizeStarted
@@ -96,6 +103,18 @@ class BlameGutterView
       item: item
     }
     @markers.push marker
+
+  wrap: (str) ->
+    span = document.createElement('span')
+    span.innerHTML = str
+    span
+
+  copySpan: (hash) ->
+    span = document.createElement('span')
+    span.setAttribute('data-hash', hash)
+    span.classList.add 'icon-copy'
+    span.addEventListener 'click', @copyClicked
+    span
 
   removeAllMarkers: ->
     marker.destroy() for marker in @markers

--- a/styles/blame.less
+++ b/styles/blame.less
@@ -3,6 +3,7 @@
 // See https://github.com/atom/atom-dark-ui/blob/master/styles/ui-variables.less
 // for a full listing of what's available.
 @import "ui-variables";
+@import "octicon-mixins";
 
 atom-text-editor::shadow {
   .gutter[gutter-name="blame"] {
@@ -10,7 +11,6 @@ atom-text-editor::shadow {
   }
   .blame-gutter {
     width: 100%;
-
     .blame-gutter-inner {
 
       padding: 0 5px;
@@ -37,6 +37,16 @@ atom-text-editor::shadow {
         right: 0;
         top: 0;
         cursor: col-resize;
+      }
+
+      .icon-copy {
+        .octicon(clippy);
+        cursor: pointer;
+        padding-right: 5px;
+      }
+
+      .icon-copy:hover {
+        color: @text-color-info;
       }
     }
   }

--- a/styles/blame.less
+++ b/styles/blame.less
@@ -13,7 +13,7 @@ atom-text-editor::shadow {
     width: 100%;
     .blame-gutter-inner {
 
-      padding: 0 5px;
+      padding: 0 25px 0 5px;
       box-sizing: border-box;
 
       white-space: nowrap;
@@ -40,9 +40,11 @@ atom-text-editor::shadow {
       }
 
       .icon-copy {
-        .octicon(clippy);
+        .octicon(clippy, @size: 1em);
         cursor: pointer;
         padding-right: 5px;
+        position: absolute;
+        right: 0;
       }
 
       .icon-copy:hover {


### PR DESCRIPTION
Sometimes it is useful to not only see who commited the line, but also to copy the hash of commit to examine the whole commit in somewhere else (e.g. in SourceTree)
