### PR TITLE
fix typo in context menu

### DIFF
--- a/menus/blame.cson
+++ b/menus/blame.cson
@@ -2,7 +2,7 @@
 'context-menu':
   'atom-text-editor': [
     {
-      'label': 'Toggle blamee'
+      'label': 'Toggle blame'
       'command': 'blame:toggle'
     }
   ]


### PR DESCRIPTION
'blamee' --> 'blame'
