### PR TITLE
open link to custom repository browser instead of bitbucket or github

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,16 @@ Show git blame as a gutter.
 
 ![](https://raw.githubusercontent.com/josa42/atom-blame/master/screenshot.png)
 
+
+## Custom repository browser
+
+To use a custom repository browser (like [gitweb](http://git-scm.com/docs/gitweb)), set an URL template in the git config file:
+
+```
+git config --local --add atom-blame.browser-url "http://example.com/gitweb/?p=my_repo.git;a=commit;h={hash}"
+```
+
+`{hash}` will be replaced with the actual hash of selected commit.
+
 Todo:
 * Handle Folding right

--- a/lib/utils/get-commit-link.coffee
+++ b/lib/utils/get-commit-link.coffee
@@ -25,16 +25,23 @@ getCommitLink = (file, hash, callback) ->
   return unless repoPath
 
   git = new Git('git-dir': repoPath)
-  git.exec 'config', get: true, ['remote.origin.url'], (error, remote) ->
-    return console.error(error) if error
+  git.exec 'config', get: true, ['atom-blame.browser-url'], (error, url) ->
 
-    remote = remote.replace(/(^\s+|\s+$)/g, '')
+    link = url.replace(/(^\s+|\s+$)/g, '')
+              .replace('{hash}', hash)
 
-    for config in configs
-      link = getLink(remote, hash, config)
-      return callback(link) if link
+    return callback(link) if link
 
-    callback(null)
+    git.exec 'config', get: true, ['remote.origin.url'], (error, remote) ->
+      return console.error(error) if error
+
+      remote = remote.replace(/(^\s+|\s+$)/g, '')
+
+      for config in configs
+        link = getLink(remote, hash, config)
+        return callback(link) if link
+
+      callback(null)
 
 
 module.exports = getCommitLink


### PR DESCRIPTION
To use a custom repository browser (like gitweb), set an URL template in
the git config file:

```
git config --local --add atom-blame.browser-url "http://example.com/gitweb/?p=my_repo.git;a=commit;h={hash}"
```

`{hash}` will be replaced with the actual hash of selected commit.
