### PR TITLE
Make http/https part of commit link dependent on repo

### DIFF
--- a/lib/config/provider.js
+++ b/lib/config/provider.js
@@ -1,17 +1,17 @@
 module.exports = [{
   // Bitbucket
   exps: [
-    /^git@(bitbucket\.org):([^\/]+)\/([^\/\.]+)\.git$/,
-    /^https:\/\/(bitbucket\.org)\/([^\/]+)\/([^\/\.]+)(\.git)?$/,
-    /^https:\/\/.+@(bitbucket\.org)\/([^\/]+)\/([^\/\.]+)(\.git)?$/
+    /^()git@(bitbucket\.org):([^\/]+)\/([^\/\.]+)\.git$/,
+    /^(https?):\/\/(bitbucket\.org)\/([^\/]+)\/([^\/\.]+)(\.git)?$/,
+    /^(https?):\/\/.+@(bitbucket\.org)\/([^\/]+)\/([^\/\.]+)(\.git)?$/
   ],
-  template: "https://{host}/{user}/{repo}/commits/{hash}"
+  template: "{protocol}://{host}/{user}/{repo}/commits/{hash}"
 },{
   // Generic (Github, GitLab and others)
   exps: [
-    /^git@(.*):(.+)\/(.+)\.git$/,
-    /^https?:\/\/([^@\/]+)\/([^\/]+)\/([^\/\.]+)(\.git)?$/,
-    /^https?:\/\/.+@([^\/]+)\/([^\/]+)\/([^\/\.]+)(\.git)?$/
+    /^()git@(.*):(.+)\/(.+)\.git$/,
+    /^(https?):\/\/([^@\/]+)\/([^\/]+)\/([^\/\.]+)(\.git)?$/,
+    /^(https?):\/\/.+@([^\/]+)\/([^\/]+)\/([^\/\.]+)(\.git)?$/
   ],
-  template: "https://{host}/{user}/{repo}/commit/{hash}"
+  template: "{protocol}://{host}/{user}/{repo}/commit/{hash}"
 }]

--- a/lib/utils/get-commit-link.js
+++ b/lib/utils/get-commit-link.js
@@ -8,7 +8,7 @@ import configs from '../config/provider'
   for (let exp of config.exps) {
     let m = remote.match(exp)
     if (m) {
-      return { host: m[1], user: m[2], repo: m[3] }
+      return { protocol: m[1], host: m[2], user: m[3], repo: m[4] }
     }
   }
 
@@ -19,6 +19,7 @@ function buildLink(remote, hash, config) {
   data = parseRemote(remote, config)
   if (data) {
     return config.template
+      .replace('{protocol}', data.protocol || 'https')
       .replace('{host}', data.host)
       .replace('{user}', data.user)
       .replace('{repo}', data.repo)


### PR DESCRIPTION
Previously commit link always used https protocol.

However, some on prem gitlab installations might use http,
so commit link with https protocol won't work for them.

Changed to determine protocol based on git remote path.
