### PR TITLE
More accurate link to datetime formatting documentation

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -19,7 +19,7 @@ export default {
       title: 'Format (date)',
       description: [
         'Placeholders: `YYYY` (year), `MM` (month), `DD` (day), `HH` (hours), `mm` (minutes).',
-        'See [momentjs documentation](http://momentjs.com/docs/) for mor information.'
+        'See [momentjs documentation](http://momentjs.com/docs/#/parsing/string-format/) for mor information.'
       ].join('<br>'),
       type: 'string',
       default: 'YYYY-MM-DD'


### PR DESCRIPTION
This link now points directly to where the string formatting portion of the
documentation lives, making is easier for the user to format their datetime.
