### PR TITLE
Remove deprecated ::shadow selectors.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "repository": "https://github.com/josa42/atom-blame",
   "license": "MIT",
   "engines": {
-    "atom": ">=1.0.0 <2.0.0"
+    "atom": ">=1.13.0 <2.0.0"
   },
   "activationCommands": {
     "atom-workspace": [

--- a/styles/blame.less
+++ b/styles/blame.less
@@ -5,9 +5,7 @@
 @import "ui-variables";
 @import "octicon-mixins";
 
-// TODO remove `::shadow` when  Atom 1.3 is stable
-atom-text-editor,
-atom-text-editor::shadow {
+atom-text-editor {
   .gutter[gutter-name="blame"] {
     border-right: 1px solid @base-border-color;
   }


### PR DESCRIPTION
These can be removed now that Atom 1.13 is stable.
Closes #29.