### PR TITLE
Adding support for long-format hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ To use a custom repository browser (like [gitweb](http://git-scm.com/docs/gitweb
 git config --local --add atom-blame.browser-url "http://example.com/gitweb/?p=my_repo.git;a=commit;h={hash}"
 ```
 
-`{hash}` will be replaced with the actual hash of selected commit.
+`{hash}` will be replaced with the actual short-format hash of selected commit.
+`{lhash}` will be replaced with the long-format hash of selected commit.
 
 Todo:
 * Handle Folding right

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ git config --local --add atom-blame.browser-url "http://example.com/gitweb/?p=my
 ```
 
 `{hash}` will be replaced with the actual short-format hash of selected commit.
-`{lhash}` will be replaced with the long-format hash of selected commit.
+`{long-hash}` will be replaced with the long-format hash of selected commit.
 
 Todo:
 * Handle Folding right

--- a/lib/blame-gutter-view.js
+++ b/lib/blame-gutter-view.js
@@ -106,7 +106,7 @@ class BlameGutterView {
     if (this.isCommited(hash)) {
       return atom.config.get('blame.gutterFormat')
         .replace('{hash}', `<span class="hash">${hash.substr(0, 8)}</span>`)
-        .replace('{lhash}', `<span class="hash">${hash}</span>`)
+        .replace('{long-hash}', `<span class="hash">${hash}</span>`)
         .replace('{date}', `<span class="date">${dateStr}</span>`)
         .replace('{author}', `<span class="author">${line.author}</span>`)
     }

--- a/lib/blame-gutter-view.js
+++ b/lib/blame-gutter-view.js
@@ -105,7 +105,8 @@ class BlameGutterView {
 
     if (this.isCommited(hash)) {
       return atom.config.get('blame.gutterFormat')
-        .replace('{hash}', `<span class="hash">${hash}</span>`)
+        .replace('{hash}', `<span class="hash">${hash.substr(0, 8)}</span>`)
+        .replace('{lhash}', `<span class="hash">${hash}</span>`)
         .replace('{date}', `<span class="date">${dateStr}</span>`)
         .replace('{author}', `<span class="author">${line.author}</span>`)
     }

--- a/lib/utils/blame.js
+++ b/lib/utils/blame.js
@@ -9,7 +9,7 @@ export default function (file, callback) {
     blamer = new Blamer('git')
   }
 
-  blamer.blameByFile(file).then(
+  blamer.blameByFile(file, "-l").then(
     (result) => callback(result[file]),
     (error) => callback(null)
   )

--- a/lib/utils/get-commit-link.js
+++ b/lib/utils/get-commit-link.js
@@ -23,7 +23,8 @@ function buildLink(remote, hash, config) {
       .replace('{host}', data.host)
       .replace('{user}', data.user)
       .replace('{repo}', data.repo)
-      .replace('{hash}', hash)
+      .replace('{hash}', hash.substr(0, 8))
+      .replace('{lhash}', hash)
   }
 
   return null
@@ -46,7 +47,8 @@ function getCommitLink(file, hash, callback) {
     if (url) {
       const link = url
         .replace(/(^\s+|\s+$)/g, '')
-        .replace('{hash}', hash)
+        .replace('{hash}', hash.substr(0, 8))
+        .replace('{lhash}', hash)
 
       if (link) {
         return callback(link)

--- a/lib/utils/get-commit-link.js
+++ b/lib/utils/get-commit-link.js
@@ -24,7 +24,7 @@ function buildLink(remote, hash, config) {
       .replace('{user}', data.user)
       .replace('{repo}', data.repo)
       .replace('{hash}', hash.substr(0, 8))
-      .replace('{lhash}', hash)
+      .replace('{long-hash}', hash)
   }
 
   return null
@@ -48,7 +48,7 @@ function getCommitLink(file, hash, callback) {
       const link = url
         .replace(/(^\s+|\s+$)/g, '')
         .replace('{hash}', hash.substr(0, 8))
-        .replace('{lhash}', hash)
+        .replace('{long-hash}', hash)
 
       if (link) {
         return callback(link)


### PR DESCRIPTION
Some repository browsers require the full long-format hash to work (VSO for example). Adding support for `{lhash}` placeholder