### PR TITLE
Use long hashes in Github and Bitbucket URLs

### DIFF
--- a/lib/config/provider.js
+++ b/lib/config/provider.js
@@ -5,7 +5,7 @@ module.exports = [{
     /^(https?):\/\/(bitbucket\.org)\/([^\/]+)\/([^\/\.]+)(\.git)?$/,
     /^(https?):\/\/.+@(bitbucket\.org)\/([^\/]+)\/([^\/\.]+)(\.git)?$/
   ],
-  template: "{protocol}://{host}/{user}/{repo}/commits/{hash}"
+  template: "{protocol}://{host}/{user}/{repo}/commits/{long-hash}"
 },{
   // Generic (Github, GitLab and others)
   exps: [
@@ -13,5 +13,5 @@ module.exports = [{
     /^(https?):\/\/([^@\/]+)\/([^\/]+)\/([^\/\.]+)(\.git)?$/,
     /^(https?):\/\/.+@([^\/]+)\/([^\/]+)\/([^\/\.]+)(\.git)?$/
   ],
-  template: "{protocol}://{host}/{user}/{repo}/commit/{hash}"
+  template: "{protocol}://{host}/{user}/{repo}/commit/{long-hash}"
 }]


### PR DESCRIPTION
While I like the short URL-s in the gutter, I think URLs should use full hashes to stand the test of time.

This way when you open the link in browser and then save it somewhere for the future, it won't become outdated when the amount of commits in repository increases to the level where the short hash that previously was unique isn't unique any more.

Though my personal motivation for this is that I have a browser extension that allows me to mark commits in Bitbucket as "read". It uses the hash in URL to remember what has been marked as read already, but it won't work consistently when the hash is shortened - and the Bitbucket commit page doesn't contain any other sensible place from where the full hash could be extracted.