### PR TITLE
Do not show `undefined` in tooltips if there is no committer

### DIFF
--- a/lib/blame-gutter-view.js
+++ b/lib/blame-gutter-view.js
@@ -318,7 +318,7 @@ class BlameGutterView {
           return
         }
         const avatar = gravatar.url(msg.author.email, { s: 80 })
-        let avatarCommiterStr
+        let avatarCommiterStr = ''
 
         let authorStr = msg.author.name
 


### PR DESCRIPTION
If the commit has no `committer`, the tooltip would show `undefined` in the place where the committer's avatar is supposed to be.

Let's get rid of that `undefined`! 🌈

_Obligatory screenshots before and after this change follow:_

#### Before

![before](https://user-images.githubusercontent.com/3058150/35674845-4425d0fc-0746-11e8-89ac-8edfa12cc504.png)

#### After

![after](https://user-images.githubusercontent.com/3058150/35674857-4bac3ec4-0746-11e8-83a7-6e5f6a50210e.png)
